### PR TITLE
Add Pro Weather to Applications & Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ _Applications and tools built using the WeatherLink APIs._
 
 - [wlbot](https://github.com/mike-weiner/wlbot) - A Node.js based CLI that can be used to make some of the most common API calls that are possible with the WeatherLink v2 API.
 - [wxtrmnl](https://github.com/mike-weiner/wxtrmnl) - A project to display WeatherLink data on a TRMNL E-ink dashboard.
+- [Pro Weather](https://pro-weather.com) - A hosted service that turns a WeatherLink account into a public weather website, auto-discovering every station and sensor through the v2 API and serving them on a subdomain or custom domain.
 
 ## Demos & Examples
 


### PR DESCRIPTION
Adds [Pro Weather](https://pro-weather.com) to **Applications & Tools**.

Pro Weather is a hosted service that turns a WeatherLink account into a public weather website. You paste a v2 API key and it auto-discovers every station and sensor on the account, then serves live conditions, historical charts and records on a subdomain or your own custom domain. It has been running in production since July 2026.

It is built directly on the WeatherLink v2 API (`/stations`, `/sensors`, `/current`, `/historic`), so it seemed a good fit alongside the other applications in that section.

Guidelines followed:

- Added on a new branch.
- Fits an existing section, no new category proposed.
- Placed at the end of the section list.
- Not a duplicate of an existing item.
- Format: `- [item name](url) - Description beginning with capital, ending in period.`
- Spelling and grammar checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)